### PR TITLE
fix: correct UTF-16 string reading in read_utf16 function

### DIFF
--- a/dump_gdbindexes.py
+++ b/dump_gdbindexes.py
@@ -51,12 +51,7 @@ def read_int32(f):
     return struct.unpack('i', v)[0]
 
 def read_utf16(f, nbcar):
-    # FIXME : only works with ASCII currently
-    val = ''
-    for j in range(nbcar):
-        val = val + '%c' % read_uint8(f)
-        f.read(1)
-    return val
+    return f.read(nbcar * 2).decode("utf-16le")
 
 f = open(filename, 'rb')
 nindexes = read_int32(f)


### PR DESCRIPTION
Updated the read_utf16 function to properly read and decode UTF-16LE strings by reading the correct number of bytes and decoding them using the utf-16le codec.

Thanks for reviewing!